### PR TITLE
go: Update version, remove go.work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Golang dynamic libs/pluging
 *.so
+
+# Local dev files
+/go.work
+/go.work.sum

--- a/build/ci/go.mod
+++ b/build/ci/go.mod
@@ -1,6 +1,6 @@
 module danger-go/dangerfile
 
-go 1.20
+go 1.21
 
 require github.com/luno/danger-go v0.2.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/danger-go
 
-go 1.20
+go 1.21
 
 require github.com/stretchr/testify v1.9.0
 

--- a/go.work
+++ b/go.work
@@ -1,6 +1,0 @@
-go 1.21
-
-use (
-	build/ci
-	.
-)

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.20
+go 1.21
 
 use (
 	build/ci

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,2 +1,4 @@
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,4 +1,0 @@
-github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=


### PR DESCRIPTION
### Changed
- Go version
 
### Removed
- go.work: generally preferable, is used for local dev ([example](https://dev.to/gophers/what-are-go-workspaces-and-how-do-i-use-them-1643)). I think this might be a cause for not being able to install with `go install github.com/luno/danger-go/cmd/danger-go` too: `outside main module or its selected dependencies`

